### PR TITLE
Add string vs numerical key table benchmark

### DIFF
--- a/files/string_vs_number_keys.lua
+++ b/files/string_vs_number_keys.lua
@@ -1,0 +1,47 @@
+
+local strtable = {}
+local numtable = {}
+local keysnum = {}
+local keysstr = {}
+
+-- This is a bit lossy since it's possible to have collisions, but the tables are identical anyway, so it shouldn't be an issue.
+for i = 1, 100000 do
+	local rand = ranStr(6)
+	keysstr[i] = rand
+	-- Packs the string into a number, basically. 6 bytes because 7 and 8 are not as easy to use. This still means strings should have the memory advantage however.
+	-- This uses a loop in case you want to play with the size of the string.
+	-- To reverse this (and check if it's true), loop from 1 to #rand, divide by the magic number and mod by 256
+	local bytes = { string.byte(rand, 1, #rand) }
+	local tonum = 0
+	for j = #rand, 1, -1 do
+		tonum = tonum + bytes[j] * 0x100 ^ (j - 1)
+	end
+	keysnum[i] = tonum
+end
+
+for k, v in ipairs(keysstr) do
+	strtable[v] = k
+end
+
+for k, v in ipairs(keysnum) do
+	numtable[v] = k
+end
+
+local sumnum = 0
+local timenum = SysTime()
+for _, v in ipairs(keysnum) do
+	sumnum = sumnum + numtable[v]
+end
+timenum = SysTime() - timenum
+
+local sumstr = 0
+local timestr = SysTime()
+for _, v in ipairs(keysstr) do
+	sumstr = sumstr + strtable[v]
+end
+timestr = SysTime() - timestr
+
+if sumnum ~= sumstr then print("Key-values in tables did not match!") end
+
+print("numtable: " .. timenum)
+print("strtable: " .. timestr)


### PR DESCRIPTION
> [!WARNING]
> This PR is dependent on #2 before merging.

This test compares accessing numerical keys versus string keys in a table. The test is performed by first creating two sequential tables of values (hereon called *key arrays*), one with string values and one with numerical values, and then inverting those tables to achieve two tables with semi-equivalent string and numerical keys. These tables are then accessed through looping over the corresponding key arrays.

Feel free to take this as inspiration for your own benchmark instead of merging this. I just did it simple and dirty, but I wanted to contribute this since I was inspired by this repo and this seems like a good place to publish my curiosity.

> [!NOTE]
> This was tested on the x64 branch

Notable results:
- Numerical indexing was almost always 2x faster than string indexing.
- String length did not seem to affect performance.

Obviously you wouldn't want to rush to convert all your tables into numerical versions all of the sudden, but for squeezing performance it might be worth considering forgoing string keys for numerical if you don't mind the readability cost. Alternatively, caching an enum might be a possible middle-ground.